### PR TITLE
Backend Login Controller and Corresponding front-end API Integration

### DIFF
--- a/taigaProject/backend/controller/login_controller.py
+++ b/taigaProject/backend/controller/login_controller.py
@@ -1,0 +1,18 @@
+import os
+import json
+from fastapi import APIRouter, Request
+from service.userstory_burndown_service import get_userstory_burndown_by_project_id
+from taigaApi.authenticate import authenticate
+
+router2 = APIRouter()
+
+@router2.post("/login")
+async def login(request:Request):
+    body = await request.body()
+    try: 
+        body = json.loads(body)
+        auth_token = authenticate(body['username'], body['password'])
+        os.environ['auth_token'] = auth_token
+        return True, "Authentication Successful", os.environ['auth_token']
+    except Exception as e:
+        return False, "Authentication failed with", e

--- a/taigaProject/backend/main.py
+++ b/taigaProject/backend/main.py
@@ -1,6 +1,10 @@
 from fastapi import FastAPI
 from controller.userstory_burndown_controller import router
+from controller.login_controller import router2
 app = FastAPI()
 app.include_router(router, prefix='/api')
+app.include_router(router2, prefix='/api')
+
+
 
 

--- a/taigaProject/frontend/package.json
+++ b/taigaProject/frontend/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "autoprefixer": "^10.4.17",
     "axios": "^1.6.7",
+    "buffer": "^6.0.3",
     "chart.js": "^4.4.1",
     "flowbite-react": "^0.7.2",
     "postcss": "^8.4.33",
@@ -46,5 +47,5 @@
       "last 1 safari version"
     ]
   },
-  "proxy": "http://api-container:8000"
+  "proxy": "http://localhost:8000"
 }

--- a/taigaProject/frontend/src/App.js
+++ b/taigaProject/frontend/src/App.js
@@ -8,6 +8,13 @@ import CycleTime from './components/CycleTime.js';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
 
 function App() {
+
+  // use the authtoke below to make sure that only the Hero page is
+  // accessible until the authToken is available { @rkhatta1 }
+
+  const authToken = localStorage.getItem('authToken');
+  console.log(authToken);
+
   return (
     <div className="container-full">
       <Router>

--- a/taigaProject/frontend/src/components/Hero.js
+++ b/taigaProject/frontend/src/components/Hero.js
@@ -1,21 +1,77 @@
 import React from 'react'
+import { useEffect, useState } from 'react';
+import axios from 'axios';
 import '../App.css'
 import SidebarMenu from './SidebarMenu'
 
 export default function Hero() {
+
+  const [loginState, setLoginState] = useState(false);
+  const [userName, setUserName] = useState("")
+  const [password, setPassword] = useState("")
+
+  const onChangeUserName = (event) => {
+    setUserName(event.target.value);
+  };
+
+  const onChangePassword = (event) => {
+    setPassword(event.target.value);
+  };
+
+  function setAuthToken() {
+    axios.post("/api/login" , {
+      "type": "normal",
+      "username": userName,
+      "password": password 
+    }).then(res => {
+        console.log("res", res.data);
+        if(res.data[0]) {
+          localStorage.setItem('authToken', res.data[2])
+          setLoginState(true);
+        }
+        else {
+          alert("authentication failed");
+        }
+      }
+    );
+  }
+
+  useEffect (() => {
+
+    const authToken = localStorage.getItem('authToken');
+
+    if (authToken) {
+      setLoginState(true)
+    }
+    else {
+      setLoginState(false)
+    }
+
+    return () => {
+      localStorage.removeItem('authToken');
+    }
+  }, [])
+  
   return (
     <div className='container-full'>
       <SidebarMenu />
       <div className='route-container'>
-        <div>
-          <span className=' teamName'>SER-516 Team Houston</span><br/>
-          <span className=' heading'>Contributors:</span><br/>
-          Raajveer Khattar<br/>
-          Rahul Manoj<br/>
-          Akash Vijayasarathy<br/>
-          Vedang Sharma<br/>
-          Siddesh Shetty<br/>
-        </div>
+        {!loginState?
+          <div style={{display: "flex", flexDirection:"column", justifyContent: "space-between"}}>
+            <input value={userName} onChange={onChangeUserName} style={{backgroundColor: "gray", marginBottom: "20px"}}/>
+            <input value={password} onChange={onChangePassword}  style={{backgroundColor: "gray", marginBottom: "20px"}}/>
+            <button style={{backgroundColor: "blue"}} onClick = {() => setAuthToken()}>Submit</button>
+          </div>
+        : <div>
+            <span className=' teamName'>SER-516 Team Houston</span><br/>
+            <span className=' heading'>Contributors:</span><br/>
+            Raajveer Khattar<br/>
+            Rahul Manoj<br/>
+            Akash Vijayasarathy<br/>
+            Vedang Sharma<br/>
+            Siddesh Shetty<br/>
+          </div> 
+        }
       </div>    
     </div>
   )


### PR DESCRIPTION
**Introduction**
This change is purely focused on the python changes for accepting login credentials on the front-end.
This change was necessary due to the necessity of having authorization credentials for requests sent to Taiga. 

This Authorization token is generated using the username and password pertaining to a user's taiga account.

**Files changed -** 
- Backend
    - Main.py (Another route has been added for the Login Controller)
    - login_controller.py(The main login controller that handles authorization) 
- Frontend
    - App.js (Illustrating use of authToken)
    - Hero.js (Login Integration for retrieving authToken)
    - package.json (npm installation file)

**Testing**
Tested API in two ways - 
- Postman
- UI directly 

**Running**
Run on local - 
front-end -> npm start
back-end -> python -m uvicorn main:app

```
API URL to use on front-end -> "/api/login" (with 3 body parameter).
{   
    "type": "normal"
    "username": "username",
    "password": "password",
}
``` 