### PR TITLE
Cache Integration, UI adjustments and data population for burndown charts (Task #82)

### DIFF
--- a/taigaProject/backend/controller/project_controller.py
+++ b/taigaProject/backend/controller/project_controller.py
@@ -1,0 +1,16 @@
+from fastapi import APIRouter, Header, Request, HTTPException
+
+from service.project_service import get_sprint_details_from_project_id
+
+project_router = APIRouter()
+
+@project_router.get("/milestone_data")
+def get_project_details(request:Request, project_slug:str):
+    access_token = request.headers.get('Authorization')
+    if access_token:
+        return get_sprint_details_from_project_id(project_slug, access_token)
+    else:
+        raise HTTPException(status_code=401, detail="Missing or invalid access token")
+
+
+

--- a/taigaProject/backend/controller/userstory_controller.py
+++ b/taigaProject/backend/controller/userstory_controller.py
@@ -15,7 +15,10 @@ def get_userstories(request:Request,sprint_id: int):
 def get_userstories_business_value_burndown(request:Request, project_id: int, sprint_id: int):
     access_token = request.headers.get('Authorization')
     if(access_token):
-        return get_userstory_custom_attribute_burndown_for_sprint(project_id, sprint_id, access_token, "BV")
+        try:
+            return get_userstory_custom_attribute_burndown_for_sprint(project_id, sprint_id, access_token, "BV")
+        except Exception as e:
+            return e
     else:
         raise HTTPException(status_code=401, detail="Missing or invalid access token")
     

--- a/taigaProject/backend/main.py
+++ b/taigaProject/backend/main.py
@@ -2,8 +2,10 @@ from fastapi import FastAPI
 from controller.userstory_controller import userstory_router
 from controller.task_controller import task_router
 from controller.login_controller import login_router
+from controller.project_controller import project_router
 
 app = FastAPI()
 app.include_router(userstory_router, prefix='/api/userstory')
 app.include_router(task_router, prefix='/api/task')
 app.include_router(login_router, prefix='/api')
+app.include_router(project_router, prefix='/api/project')

--- a/taigaProject/backend/service/project_service.py
+++ b/taigaProject/backend/service/project_service.py
@@ -1,0 +1,17 @@
+from fastapi import HTTPException
+from taigaApi.project.getProjectBySlug import get_project_by_slug
+
+def get_sprint_details_from_project_id(project_slug, auth_token):
+    
+    response = {}
+    try: 
+        project_info = get_project_by_slug(project_slug, auth_token)
+        project_id = project_info['id']
+        response[project_id] = project_info['milestones']
+
+        return response
+    
+    except Exception as e:
+        raise HTTPException(status_code=401, detail="{e}")
+
+

--- a/taigaProject/frontend/package-lock.json
+++ b/taigaProject/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "react-pro-sidebar": "^1.1.0",
         "react-router-dom": "^6.22.0",
         "react-scripts": "^5.0.1",
+        "react-spinners": "^0.13.8",
         "react-tabs": "^6.0.2",
         "tailwindcss": "^3.4.1",
         "web-vitals": "^2.1.4"
@@ -21681,6 +21682,15 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-spinners": {
+      "version": "0.13.8",
+      "resolved": "https://registry.npmjs.org/react-spinners/-/react-spinners-0.13.8.tgz",
+      "integrity": "sha512-3e+k56lUkPj0vb5NDXPVFAOkPC//XyhKPJjvcGjyMNPWsBKpplfeyialP74G7H7+It7KzhtET+MvGqbKgAqpZA==",
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-tabs": {

--- a/taigaProject/frontend/package.json
+++ b/taigaProject/frontend/package.json
@@ -23,6 +23,7 @@
     "react-pro-sidebar": "^1.1.0",
     "react-router-dom": "^6.22.0",
     "react-scripts": "^5.0.1",
+    "react-spinners": "^0.13.8",
     "react-tabs": "^6.0.2",
     "tailwindcss": "^3.4.1",
     "web-vitals": "^2.1.4"

--- a/taigaProject/frontend/src/App.css
+++ b/taigaProject/frontend/src/App.css
@@ -2,7 +2,6 @@
 @tailwind components;
 @tailwind utilities;
 
-
 body {
   height: 100%;
   width: auto;
@@ -67,9 +66,39 @@ body {
 }
 
 .graph-container {
-  min-height: 100vh;
+  height: "100%";
   min-width: 100vh;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
+}
+
+.spinner-border {
+  display: inline-block;
+  width: 2rem;
+  height: 2rem;
+  border: 0.25em solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+  animation: spin 0.75s linear infinite;
+}
+
+@keyframes spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
 }

--- a/taigaProject/frontend/src/components/Burndown.js
+++ b/taigaProject/frontend/src/components/Burndown.js
@@ -14,11 +14,22 @@ export default function Burndown() {
   const [partialStoryPointBurnDownData, setPartialStoryPointBurnDownData] = useState(null);
   const [fullStoryPointBurnDownData, setFullStoryPointBurnDownData] = useState(null);
 
+
+  function doubleCheck(url, updateCall, scenario, authToken) {
+
+    apiCall(url, updateCall, scenario, authToken)
+    let count = 0
+    setTimeout(() => {
+      doubleCheck(url, updateCall, scenario, authToken)
+    }, 30000)
+  }
+
   function apiCall(url, updateCall, scenario, authToken) {
+
     axios.get(url, {
-      headers: {
-        'Authorization': authToken
-      }}
+        headers: {
+          'Authorization': authToken
+        }}
     )
     .then(res => {
 
@@ -41,10 +52,10 @@ export default function Burndown() {
           hoverOffset: 4
         }]
       }
+        updateCall(updated);
+      }
+    );    
     
-      updateCall(updated);
-    }
-    );
   }
 
   useEffect (() => {
@@ -53,14 +64,14 @@ export default function Burndown() {
     console.log("authToken", authToken);
 
     if(!businessValueBurnDownData && authToken)  {
-      apiCall('/api/userstory/business_value_burndown?project_id=1521718&sprint_id=376612', setBusinessValueBurnDownData, "business value", authToken);
+      doubleCheck('/api/userstory/business_value_burndown?project_id=1521718&sprint_id=376612', setBusinessValueBurnDownData, "business value", authToken);
     }
 
     if(!partialStoryPointBurnDownData && authToken) {
-      // apiCall('/api/userstory/userstory_burndown?project_id=1522285', setPartialStoryPointBurnDownData, "partial storypoints", authToken);
+      // doubleCheck('/api/userstory/userstory_burndown?project_id=1522285', setPartialStoryPointBurnDownData, "partial storypoints", authToken);
     }
     if(!fullStoryPointBurnDownData && authToken) {
-      // apiCall('/api/userstory/userstory_burndown?project_id=1522285', setFullStoryPointBurnDownData, "partial storypoints", authToken);
+      // doubleCheck('/api/userstory/userstory_burndown?project_id=1522285', setFullStoryPointBurnDownData, "partial storypoints", authToken);
     }
 
   }, []);

--- a/taigaProject/frontend/src/components/Burndown.js
+++ b/taigaProject/frontend/src/components/Burndown.js
@@ -3,6 +3,7 @@ import axios from 'axios';
 import { useEffect, useState } from 'react'
 import '../App.css'
 import LineChartMaker from './reusable_components/LineChartMaker'
+import commonApiCall from '../commons'
 import SidebarMenu from './SidebarMenu';
 import { Tab, Tabs, TabList, TabPanel } from 'react-tabs';
 import 'react-tabs/style/react-tabs.css';
@@ -14,14 +15,37 @@ export default function Burndown() {
   const [partialStoryPointBurnDownData, setPartialStoryPointBurnDownData] = useState(null);
   const [fullStoryPointBurnDownData, setFullStoryPointBurnDownData] = useState(null);
 
+  const [projectSlug, setProjectSlug] = useState(null)
+  const [sprintData, setSprintData] = useState([])
 
-  function doubleCheck(url, updateCall, scenario, authToken) {
+  const [selectedOption, setSelectedOption] = useState('');
 
-    apiCall(url, updateCall, scenario, authToken)
-    let count = 0
-    setTimeout(() => {
-      doubleCheck(url, updateCall, scenario, authToken)
-    }, 30000)
+  const [projectId, setProjectId] = useState(null)
+  const [sprintId, setSprintId] = useState(null)
+
+  const [showLoader, setShowLoader] = useState(false)
+
+  const clearData = () => {
+    setSprintData([])
+    setSprintId(null)
+    setBusinessValueBurnDownData(null)
+    setPartialStoryPointBurnDownData(null)
+    setFullStoryPointBurnDownData(null)
+    setSelectedOption('')
+    setShowLoader(false)
+  }
+
+  const handleDropdownChange = (e) => {
+    setSelectedOption(e.target.value);
+    console.log(e.target.value)
+    setSprintId(e.target.value)
+    setShowLoader(true)
+  };
+
+  function onChangeProjectSlug(event) {
+    setProjectSlug(event.target.value)
+    clearData()
+
   }
 
   function apiCall(url, updateCall, scenario, authToken) {
@@ -36,6 +60,8 @@ export default function Burndown() {
       console.log("res", res.data);
       const labels = Object.keys(res.data);
       const values = Object.values(res.data);
+      setShowLoader(false)
+
       labels[0] = "";
       const updated = {
         labels: labels,
@@ -43,7 +69,7 @@ export default function Burndown() {
         datasets: [{
           label: 'Burndown Data',
           data: values,
-          borderColor: 'rgb(255, 99, 132)',
+          borderColor: 'black',
           backgroundColor: [
             'rgb(255, 99, 132)',
             'rgb(255, 205, 86)'
@@ -51,48 +77,95 @@ export default function Burndown() {
           hoverOffset: 4
         }]
       }
-        updateCall(updated);
-      }
-    );    
+      updateCall(updated);
+    });    
     
+  }
+
+  function setProjectDetails() {
+    
+    const authToken = localStorage.getItem('authToken');
+    let url = '/api/project/milestone_data?project_slug=' + projectSlug
+    
+    axios.get(url, {
+      headers: {
+          'Authorization': authToken
+      }
+    }).then(result => {
+      console.log("result", result.data)
+      console.log("p_id", Object.keys(result.data)[0])
+      
+      let p_id = Object.keys(result.data)[0]
+      let s_Data = result.data[p_id]
+      console.log(s_Data)
+      setProjectId(p_id)
+      setSprintData(s_Data)
+      setShowLoader(true)
+
+    })
   }
 
   useEffect (() => {
 
-    const authToken = localStorage.getItem('authToken');
-    console.log("authToken", authToken);
+    const callApis = () => {
 
-    if(!businessValueBurnDownData && authToken)  {
-      doubleCheck('/api/userstory/business_value_burndown?project_id=1521718&sprint_id=376612', setBusinessValueBurnDownData, "business value", authToken);
-    }
-    if(!partialStoryPointBurnDownData && authToken) {
-      doubleCheck('/api/userstory/partial_userstory_burndown?sprint_id=376612', setPartialStoryPointBurnDownData, "partial storypoints", authToken);
-    }
-    if(!fullStoryPointBurnDownData && authToken) {
-      doubleCheck('/api/userstory/userstory_burndown?sprint_id=376612', setFullStoryPointBurnDownData, "full storypoints", authToken);
+      const authToken = localStorage.getItem('authToken');
+      console.log("authToken", authToken);
+      console.log("sprintId", sprintId)
+      console.log("projectId", projectId)
+
+      if(authToken && projectId && sprintId)  {
+        apiCall(`/api/userstory/business_value_burndown?project_id=${projectId}&sprint_id=${sprintId}`, setBusinessValueBurnDownData, "business value", authToken);
+      }
+      if(authToken && sprintId) {
+        apiCall(`/api/userstory/partial_userstory_burndown?sprint_id=${sprintId}`, setPartialStoryPointBurnDownData, "partial storypoints", authToken);
+      }
+      if(authToken && sprintId) {
+        apiCall(`/api/userstory/userstory_burndown?sprint_id=${sprintId}`, setFullStoryPointBurnDownData, "full storypoints", authToken);
+      }
+
     }
 
-  }, []);
+    callApis();
+
+    const intervalId = setInterval(callApis, 30000);
+    return () => clearInterval(intervalId);
+
+  }, [sprintId, projectId]);
 
   return (
-    <div className='container-full bg-gradient-to-r from-[#00f9f9] to-[#ffffff]'>
+    <div className='container-full bg-gradient-to-r from-[#FFB32C] to-[#ffd12c]'>
       <div className='route-container'>
-        <Tabs>
+        <Tabs style={{display: "flex", justifyContent: "space-between", flexDirection:"column"}}>
           <TabList style={{display: 'flex', justifyContent: "space-between"}}>
             <Tab>Partial SP Burndown</Tab>
             <Tab>Full SP Burndown</Tab>
             <Tab>Business Value Burndown</Tab>
           </TabList>
+          <div style={{display: "flex", flexDirection:"column", justifyContent: "space-between", width: "50%"}}>
+            <span className='text-[1.2rem] font-bold font-sans'>Project Slug:</span>
+            <input className='bg-white border-2 rounded-xl hover:rounded-none duration-300 border-black h-[2.3rem] px-3 text-[1rem] font-sans' type='username' value={projectSlug} onChange={onChangeProjectSlug} aria-label='username' style={{marginBottom: "20px"}}/>
+            <button className=' p-4 border-4 border-blue-950 hover:bg-blue-950 duration-300 hover:text-white font-sans font-bold rounded-2xl hover:rounded-none' onClick = {() => setProjectDetails()}>Submit</button>
+            {sprintData.length > 0?
+              <select value={selectedOption} onChange={handleDropdownChange} style={{marginTop: "10px"}}>
+                <option value="">Select an option</option>
+                {sprintData.map((item) => (
+                  <option key={item.id} value={item.id}>
+                    {item.name}
+                  </option>
+                ))}
+              </select> : null }
+          </div>
+           <TabPanel>
+              <LineChartMaker data = {partialStoryPointBurnDownData} showLoader={showLoader}/> 
+          </TabPanel>
+          <TabPanel>
+              <LineChartMaker data = {fullStoryPointBurnDownData} showLoader={showLoader}/>
+          </TabPanel>
+          <TabPanel>
+              <LineChartMaker data = {businessValueBurnDownData} showLoader={showLoader}/>
+          </TabPanel>
 
-          <TabPanel>
-            <LineChartMaker props = {partialStoryPointBurnDownData}/>
-          </TabPanel>
-          <TabPanel>
-            <LineChartMaker props = {fullStoryPointBurnDownData}/>
-          </TabPanel>
-          <TabPanel>
-            <LineChartMaker props = {businessValueBurnDownData}/>
-          </TabPanel>
         </Tabs>
       </div>
     </div>

--- a/taigaProject/frontend/src/components/Burndown.js
+++ b/taigaProject/frontend/src/components/Burndown.js
@@ -46,7 +46,6 @@ export default function Burndown() {
           borderColor: 'rgb(255, 99, 132)',
           backgroundColor: [
             'rgb(255, 99, 132)',
-            'rgb(54, 162, 235)',
             'rgb(255, 205, 86)'
           ],
           hoverOffset: 4
@@ -66,12 +65,11 @@ export default function Burndown() {
     if(!businessValueBurnDownData && authToken)  {
       doubleCheck('/api/userstory/business_value_burndown?project_id=1521718&sprint_id=376612', setBusinessValueBurnDownData, "business value", authToken);
     }
-
     if(!partialStoryPointBurnDownData && authToken) {
-      // doubleCheck('/api/userstory/userstory_burndown?project_id=1522285', setPartialStoryPointBurnDownData, "partial storypoints", authToken);
+      doubleCheck('/api/userstory/partial_userstory_burndown?sprint_id=376612', setPartialStoryPointBurnDownData, "partial storypoints", authToken);
     }
     if(!fullStoryPointBurnDownData && authToken) {
-      // doubleCheck('/api/userstory/userstory_burndown?project_id=1522285', setFullStoryPointBurnDownData, "partial storypoints", authToken);
+      doubleCheck('/api/userstory/userstory_burndown?sprint_id=376612', setFullStoryPointBurnDownData, "full storypoints", authToken);
     }
 
   }, []);

--- a/taigaProject/frontend/src/components/SidebarMenu.js
+++ b/taigaProject/frontend/src/components/SidebarMenu.js
@@ -1,7 +1,7 @@
 import React from 'react'
 // import { Sidebar } from 'flowbite-react'
 // import { Sidebar, Menu, MenuItem, SubMenu } from 'react-pro-sidebar';
-import { Sidebar, Menu, MenuItem, useProSidebar, menuClasses } from "react-pro-sidebar";
+import { Sidebar, Menu, MenuItem, useProSidebar, menuClasses, sidebarClasses } from "react-pro-sidebar";
 import HomeOutlinedIcon from "@mui/icons-material/HomeOutlined";
 import PeopleOutlinedIcon from "@mui/icons-material/PeopleOutlined";
 import ContactsOutlinedIcon from "@mui/icons-material/ContactsOutlined";
@@ -64,41 +64,41 @@ export default function SidebarMenu() {
         
     // </div>
     <div className='font-sans font-semibold'>
-    <div id="app" style={({ height: "100vh" }, { display: "flex", flexDirection: "row" })}>
-    <Sidebar
-        rootStyles={{
-          borderColor: "rgb(0, 249, 249)",
-          // backgroundColor: 'rgb(0, 249, 249)'
-          ['.' + menuClasses.button]: {
-            '&:hover' : {
-              backgroundColor: '#9CAF88',
-              transitionDuration: '0.3s',
-              // colors: '#000000',
+      <div id="app" style={({ height: "100vh" }, { display: "flex", flexDirection: "row" })}>
+        <Sidebar
+          rootStyles={{
+            ['.' + menuClasses.button]: {
+              '&:hover' : {
+                transitionDuration: '0.3s',
+                backgroundColor: "#FFC72C"
+                // colors: '#000000',
+              }
+            },
+            [`.${sidebarClasses.container}`]: {
+              background: 'linear-gradient(to right, #781d40 0%, #a01d40 100%)'
             }
-          }
-        }}
-        backgroundColor="rgb(0, 249, 249)"
-        rtl={false}
-        style={{ height: "100vh" }}>
-      <Menu>
-        <MenuItem
-          icon={<MenuOutlinedIcon />}
-          
-          onClick={() => {
-            collapseSidebar();
           }}
-          style={{ textAlign: "center" }}
-        >
-          {" "}
-        </MenuItem>
+          rtl={false}
+          style={{ height: "100vh" }}>
+          <Menu>
+            <MenuItem
+              icon={<MenuOutlinedIcon />}
+              
+              onClick={() => {
+                collapseSidebar();
+              }}
+              style={{ textAlign: "center" }}
+            >
+              {" "}
+            </MenuItem>
 
-        <MenuItem active icon={<HomeOutlinedIcon />} component={<Link to={"/"} />}>Home</MenuItem>
-        <MenuItem active icon={<PeopleOutlinedIcon />} component={<Link to={"/burndowncharts"} />}>Burndown Charts</MenuItem>
-        <MenuItem active icon={<ContactsOutlinedIcon />} component={<Link to={"/cycletime"} />}>Cycle Time</MenuItem>
-        <MenuItem active icon={<ReceiptOutlinedIcon />} component={<Link to={"/leadtime"} />}>Lead Time</MenuItem>
-      </Menu>
-    </Sidebar>
-    </div>
+            <MenuItem active icon={<HomeOutlinedIcon />} component={<Link to={"/"} />}>Home</MenuItem>
+            <MenuItem active icon={<PeopleOutlinedIcon />} component={<Link to={"/burndowncharts"} />}>Burndown Charts</MenuItem>
+            <MenuItem active icon={<ContactsOutlinedIcon />} component={<Link to={"/cycletime"} />}>Cycle Time</MenuItem>
+            <MenuItem active icon={<ReceiptOutlinedIcon />} component={<Link to={"/leadtime"} />}>Lead Time</MenuItem>
+          </Menu>
+        </Sidebar>
+      </div>
     </div>
   )
 }

--- a/taigaProject/frontend/src/components/reusable_components/LineChartMaker.js
+++ b/taigaProject/frontend/src/components/reusable_components/LineChartMaker.js
@@ -12,6 +12,10 @@ import {
 
 import 'chart.js/auto';
 
+import Loader from './Loader';
+
+import '../../App.css'
+
 import { Line } from "react-chartjs-2"
 
 ChartJS.register(
@@ -24,7 +28,7 @@ ChartJS.register(
     Legend
 );
 
-export default function LineChartMaker({props}) {
+export default function LineChartMaker(props) {
 
     console.log("props", props);
 
@@ -36,7 +40,7 @@ export default function LineChartMaker({props}) {
         },
         title: {
           display: true,
-          text: props? props.text: "",
+          text: props && props.data? props.data.text: "",
         },
       },
       indexAxis: 'x',
@@ -47,16 +51,19 @@ export default function LineChartMaker({props}) {
       }
     };
     const data = {
-      labels: props? props.labels: [],
-      datasets: props? props.datasets : []
+      labels: props && props.data? props.data.labels: [],
+      datasets: props && props.data? props.data.datasets : []
     };
 
     return (
       <div className='graph-container'>
-        <Line 
-          data = {data} 
-          options = {options}
-        />
+        {props && props.showLoader? 
+          <Loader/> 
+          : <Line 
+            data = {data} 
+            options = {options}
+          /> 
+        }
       </div>
     );
 }

--- a/taigaProject/frontend/src/components/reusable_components/Loader.js
+++ b/taigaProject/frontend/src/components/reusable_components/Loader.js
@@ -1,0 +1,12 @@
+import '../../App.css'
+
+export default function Loader () {
+    
+    return (
+        <div style={{backgroundColor: "red"}}>
+            <div className="spinner-border" role="status">
+            <span className="visually-hidden">Loading...</span>
+            </div>
+        </div>
+    )
+}


### PR DESCRIPTION
**Description**
3 burndown charts are functionally complete - 

- Business value burndown chart
- Full story-point burndown chart
- Partial story-point burndown chart

**Testing**
Tested directly on the front-end

**Additional feature added**
Code dynamically updates. Every thirty seconds an api call is made to the backend from the frontend. 
This call has two parts. We use threading to start a background task which completes the api computation on it's own.
While cache data is populated sent to the front-end. In the case that cache data isn't present, it makes the api call directly.

**Things left to do**

Code should consume project_id and sprint_id from the user through project slug and sprint name. This will be completed in the next PR.
